### PR TITLE
Fix #4: Indicate scope using css

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -38,7 +38,7 @@ body {
 }
 
 .scope {
-  &.selected {
+  &[data-selected="true"] {
     background-color: #BFBFBF;
     background-image: none;
   }

--- a/app/views/planting_tasks/filtered_index.html.haml
+++ b/app/views/planting_tasks/filtered_index.html.haml
@@ -3,7 +3,8 @@
     = link_to 'New Crop', new_planting_task_path,  class:  'btn btn-primary'
   .btn-group
     - @scopes.each do |scope|
-      .btn.scope{data: {name: scope.to_s.titleize }}= link_to "#{scope.to_s.titleize}", root_path(scope: scope)
+      .btn.scope{ data: {name: scope.to_s.titleize, selected: ((scope.to_s == @scope.to_s) ? "true" : nil) } }
+        = link_to "#{scope.to_s.titleize}", root_path(scope: scope)
   - if @tasks.empty?
     %h2 No matching crops
   - else


### PR DESCRIPTION
## Description

Indicate what scope filter you're on using css
## Steps to test
- Go to http://localhost:3000
- It should look like this:
  ![image](https://cloud.githubusercontent.com/assets/484191/16822480/a9c5f38c-4911-11e6-8e3d-13d507c64ed0.png)
- Click on one of the scopes
- Now it should look like this:
  ![image](https://cloud.githubusercontent.com/assets/484191/16822490/b57c0716-4911-11e6-83a5-d9e130f37a4f.png)
## Fixes

Fix #4 
